### PR TITLE
feat: add year period

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,14 @@ function App() {
       ]
       break;
 
+    case "year":
+      maxWidth = "300px";
+      cellSize = "15px";
+      listOutput = months.map((month) => (
+        <TimeItemList key={month} maxWidth={maxWidth} cellSize={cellSize} desc={`year_${month}`} />
+      ));
+      break;
+
     default:
       console.log('No such period exists!');
   }

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -2,6 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   gap: 3rem;
 }

--- a/src/assets/css/Time/TimeItemList.css
+++ b/src/assets/css/Time/TimeItemList.css
@@ -3,7 +3,7 @@
   margin-top: 1rem;
   display: flex;
   flex-wrap: wrap;
-  justify-content: center; 
+  justify-content: flex-start; 
   align-items: center;
   gap: 1rem;
 }

--- a/src/components/TimeDetails.jsx
+++ b/src/components/TimeDetails.jsx
@@ -18,8 +18,11 @@ const TimeDetails = () => {
     dayTimePerc,
     getMonthDays,
     getDaysSinceMonthStart,
+    getDayOfYear,
+    isLeapYear 
   } = useBetween(useTime);
 
+  const yearDays = isLeapYear(time.getFullYear()) ? 366 : 365;
   let detailOutput = "";
   switch (period) {
     case "today":
@@ -36,6 +39,10 @@ const TimeDetails = () => {
         " / " +
         getMonthDays(months[time.getMonth()]) +
         " days";
+      break;
+
+    case "year":
+      detailOutput = getDayOfYear(time) + " / " + yearDays + " days";
       break;
 
     default:

--- a/src/components/TimeItemList.jsx
+++ b/src/components/TimeItemList.jsx
@@ -6,12 +6,14 @@ import { useTime } from "../hooks/useTime";
 const TimeList = ({ maxWidth, cellSize, desc }) => {
   const {
     time,
+    period, 
     getWeekTime,
     dayTimePerc,
     daysOfWeek,
     months,
     getMonthDays,
     getMonthTime,
+    getYearTime
   } = useBetween(useTime);
   const dayItemsCount = Math.floor(dayTimePerc);
 
@@ -41,6 +43,17 @@ const TimeList = ({ maxWidth, cellSize, desc }) => {
         cellSize={cellSize}
       />
     ));
+  } else if (months.includes(desc.split("_")[1])) {
+    const month = desc.split("_")[1];
+    desc = month; 
+
+    timeItems = Array.from({ length: getMonthDays(month) }, (_, index) => (
+      <TimeItem
+        key={index}
+        isActive={getYearTime(month, index)}
+        cellSize={cellSize}
+      />
+    ));
   } else {
     console.log("No such period exists!");
   }
@@ -56,7 +69,7 @@ const TimeList = ({ maxWidth, cellSize, desc }) => {
     <div className="time-list-wrapper" style={listStyle}>
       <h2 className={`list-title ${descStyle}`}>
         {capitalize(desc)}
-        {months.includes(desc) ? `, ${time.getFullYear()}` : ""}
+        {period === "month" ? `, ${time.getFullYear()}` : ""}
       </h2>
       <div className="time-list">{timeItems}</div>
     </div>

--- a/src/hooks/useTime.js
+++ b/src/hooks/useTime.js
@@ -115,7 +115,7 @@ export const useTime = () => {
 
     if (month === "february") {
       const year = time.getFullYear();
-      if ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0) {
+      if (isLeapYear(year)) {
         return 29;
       }
     }
@@ -127,12 +127,34 @@ export const useTime = () => {
   const getMonthTime = (index) => {
     const todayDate = time.getDate();
     return index < todayDate;
-  }
+  };
 
   // MONTH - Get days since the start of the month
   const getDaysSinceMonthStart = () => {
     return time.getDate();
   };
+  
+  // YEAR - Constants
+  const firstDayOfYear = new Date(time.getFullYear(), 0, 1);
+
+  // YEAR - Is the year a leap year?
+  const isLeapYear = (year) => {
+    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  };
+
+   // YEAR - Get the day of the year (1-365)
+  const getDayOfYear = (date) => {
+    const diff = date - firstDayOfYear;
+    const oneDay = 1000 * 60 * 60 * 24;
+    const day = Math.floor(diff / oneDay);
+    return day + 1;
+  };
+
+  // YEAR - This is to check if the month has passed
+  const getYearTime = (month, index) => {
+    const tempDayOfYear = getDayOfYear(new Date(time.getFullYear(), months.indexOf(month) + 1, index + 1));
+    return tempDayOfYear < getDayOfYear(time);
+  }; 
 
   return {
     period,
@@ -147,6 +169,9 @@ export const useTime = () => {
     months,
     getMonthDays,
     getMonthTime,
-    getDaysSinceMonthStart
+    getDaysSinceMonthStart,
+    getDayOfYear, 
+    getYearTime,
+    isLeapYear 
   };
 };


### PR DESCRIPTION
## Description
Add year period functionality for user input

## Changes
- Add `isLeapYear`, `getDayOfYear`, `getYearTime` methods for year period
- Refactor the check inside a `if` statement into its separate function (`isLeapYear`)
- The overflown `timeCells` are now at the beginning instead of center (`align-items`)